### PR TITLE
Drain spot instances on termination

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @springload/devops

--- a/cloud-init.tf
+++ b/cloud-init.tf
@@ -10,6 +10,7 @@ data "template_cloudinit_config" "config" {
     content = <<-EOT
       #!/bin/bash
       echo "ECS_CLUSTER=${aws_ecs_cluster.main.name}" >> /etc/ecs/ecs.config
+      %{if var.spot == true}echo "ECS_ENABLE_SPOT_INSTANCE_DRAINING=true" >> /etc/ecs/ecs.config%{endif}
 
       EOT
   }


### PR DESCRIPTION
This adds the capability to drain spot instances when they are terminated, and is enabled by default.

Reference: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/container-instance-spot.html