### PR TITLE
Allow autoscaling cluster based on ECS requirements

### DIFF
--- a/cloud-init.tf
+++ b/cloud-init.tf
@@ -1,5 +1,5 @@
-data "template_cloudinit_config" "config" {
-  count = var.instances_desired > 0 ? 1 : 0
+data "cloudinit_config" "config" {
+  count = var.instances_desired > 0 || var.instances_autoscale_max > 0 ? 1 : 0
 
   gzip          = false
   base64_encode = true

--- a/data.tf
+++ b/data.tf
@@ -7,6 +7,8 @@ data "aws_vpc" "main" {
 }
 
 data "aws_ami" "ami" {
+  count = var.ami == "" ? 0 : 1
+
   most_recent = true
 
   filter {
@@ -18,10 +20,18 @@ data "aws_ami" "ami" {
   owners = ["amazon"]
 }
 
-data "aws_security_groups" "groups" {
+data "aws_ssm_parameter" "recommended_ami" {
+  count = var.ami == "" ? 1 : 0
+
+  name = "/aws/service/ecs/optimized-ami/amazon-linux-2023/recommended"
+}
+
+data "aws_security_group" "group" {
+  count = length(var.security_groups)
+
   filter {
     name   = "group-name"
-    values = var.security_groups
+    values = [var.security_groups[count.index]]
   }
 
   filter {
@@ -30,7 +40,10 @@ data "aws_security_groups" "groups" {
   }
 }
 
-data "aws_subnet_ids" "subnets" {
-  vpc_id = data.aws_vpc.main.id
+data "aws_subnets" "subnets" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.main.id]
+  }
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,9 +7,9 @@ output "cluster_name" {
 }
 
 output "asg_arn" {
-  value = var.instances_desired > 0 ? aws_autoscaling_group.ASG[0].arn : null
+  value = var.instances_desired > 0 || var.instances_autoscale_max > 0 ? aws_autoscaling_group.ASG[0].arn : null
 }
 
 output "asg_name" {
-  value = var.instances_desired > 0 ? aws_autoscaling_group.ASG[0].name : null
+  value = var.instances_desired > 0 || var.instances_autoscale_max > 0 ? aws_autoscaling_group.ASG[0].name : null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -11,7 +11,7 @@ variable "cluster_name" {
 variable "ami" {
   type        = string
   description = "Name of the AMI image to use"
-  default     = "amzn2-ami-ecs-hvm-*-x86_64-ebs"
+  default     = ""
 }
 
 variable "cloud_init_parts" {
@@ -59,24 +59,29 @@ variable "instance_refresh" {
 variable "instances_desired" {
   type        = number
   description = "Number of EC2 instances desired"
-  default     = 1
+  default     = 0
+}
+variable "instances_autoscale_max" {
+  type        = number
+  description = "The maximum number of EC2 instances when using autoscaling"
+  default     = 10
 }
 
 variable "metadata_options" {
-  type        = map
+  type        = map(any)
   description = "Map of metadata options"
   default     = {}
 }
 
 variable "security_groups" {
-  type        = list
+  type        = list(any)
   description = "list of security group names"
   default     = []
 }
 
 variable "subnet_ids" {
   description = "list of subnet ids. By default takes all subnets from the VPC"
-  type        = list
+  type        = list(any)
   default     = []
 }
 
@@ -87,7 +92,7 @@ variable "spot" {
 }
 
 variable "tags" {
-  type        = map
+  type        = map(any)
   description = "instances tags"
   default     = {}
 }

--- a/versions.tf
+++ b/versions.tf
@@ -2,11 +2,11 @@ terraform {
   required_version = ">= 0.13"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
+      version = "> 5.0, < 6"
     }
-    template = {
-      source  = "hashicorp/template"
-      version = "~> 2.1"
+    cloudinit = {
+      source = "hashicorp/cloudinit"
     }
   }
 }


### PR DESCRIPTION
Should be backwards compatible with the old behaviour
Replace template provider with cloudinit
